### PR TITLE
Resolve the error

### DIFF
--- a/validate_extension.py
+++ b/validate_extension.py
@@ -207,8 +207,11 @@ def main():
     print("🔍 AI Language Translator Chrome 扩展验证")
     print("="*60)
     
-    # Change to workspace directory
-    os.chdir('/workspace')
+    # Change to script directory if manifest.json is not in current directory
+    if not os.path.exists('manifest.json'):
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        print(f"📁 切换到脚本目录: {script_dir}")
+        os.chdir(script_dir)
     
     # Run all checks
     manifest_ok = check_manifest()


### PR DESCRIPTION
Fix validation script execution error by removing hardcoded `/workspace` path.

The `validate_extension.py` script previously hardcoded `os.chdir('/workspace')`, which caused errors when run in environments where this directory did not exist. This change makes the script more robust by first checking for `manifest.json` in the current directory, and if not found, switching to the script's own directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-47703ab5-8a03-4999-8271-6bbba40be249">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47703ab5-8a03-4999-8271-6bbba40be249">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

