### PR TITLE
Rename ai-language-translator to tidy

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,4 +1,4 @@
-# AI Language Translator 安装和测试指南
+# Tidy 安装和测试指南
 
 ## 📦 安装步骤
 
@@ -150,7 +150,7 @@
 
 ### 查看扩展日志
 1. 进入 `chrome://extensions/`
-2. 找到 AI Language Translator 扩展
+2. 找到 Tidy 扩展
 3. 点击"检查视图 service worker"
 4. 在控制台中查看后台脚本日志
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# AI Language Translator Browser Extension
+# Tidy Browser Extension
 
 ## 产品概述
 
-AI Language Translator 是一款基于人工智能的浏览器翻译插件，旨在为用户提供沉浸式的双语阅读体验，提升信息获取效率。该插件支持多种翻译场景，包括网页翻译、PDF文档翻译、图片翻译、视频字幕翻译等。
+Tidy 是一款基于人工智能的浏览器翻译插件，旨在为用户提供沉浸式的双语阅读体验，提升信息获取效率。该插件支持多种翻译场景，包括网页翻译、PDF文档翻译、图片翻译、视频字幕翻译等。
 
 ## 核心功能
 
@@ -78,7 +78,7 @@ cd tify
 ```
 build/
 └── dist/
-    ├── ai-language-translator-v1.0.0.zip    # 用于Chrome Web Store
+    ├── tidy-v1.0.0.zip    # 用于Chrome Web Store
     └── extension-dev/                        # 用于开发者模式
         ├── manifest.json
         └── src/
@@ -105,7 +105,7 @@ build/
 1. 访问 [Chrome 开发者控制台](https://chrome.google.com/webstore/devconsole/)
 2. 登录你的 Google 开发者账户
 3. 点击 **"添加新项"**
-4. 上传 `build/dist/ai-language-translator-v1.0.0.zip` 文件
+4. 上传 `build/dist/tidy-v1.0.0.zip` 文件
 5. 按照指引完成发布流程
 
 ### 构建脚本功能
@@ -345,7 +345,7 @@ src/
 
 ## 总结
 
-AI Language Translator 浏览器插件旨在通过先进的AI技术，为用户提供高质量的沉浸式翻译体验。产品设计注重用户体验、功能完整性和技术先进性，通过免费+付费的商业模式实现可持续发展。
+Tidy 浏览器插件旨在通过先进的AI技术，为用户提供高质量的沉浸式翻译体验。产品设计注重用户体验、功能完整性和技术先进性，通过免费+付费的商业模式实现可持续发展。
 
 该产品将帮助用户打破语言障碍，提升信息获取效率，成为跨语言交流的重要工具。
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# AI Language Translator Chrome Extension Build Script
+# Tidy Chrome Extension Build Script
 # 用于macOS的构建脚本
 
 set -e  # 遇到错误时停止执行
@@ -62,7 +62,7 @@ PROJECT_DIR="$SCRIPT_DIR"
 BUILD_DIR="$PROJECT_DIR/build"
 DIST_DIR="$BUILD_DIR/dist"
 TEMP_DIR="$BUILD_DIR/temp"
-ZIP_NAME="ai-language-translator"
+ZIP_NAME="tidy"
 
 # 从manifest.json读取版本号
 if [[ -f "$PROJECT_DIR/manifest.json" ]]; then
@@ -103,7 +103,7 @@ EXCLUDE_PATTERNS=(
 )
 
 main() {
-    log_info "开始构建 AI Language Translator Chrome 扩展..."
+    log_info "开始构建 Tidy Chrome 扩展..."
     
     # 检查依赖
     check_dependencies
@@ -210,7 +210,7 @@ main() {
 
 # 显示帮助信息
 show_help() {
-    echo "AI Language Translator Chrome Extension Build Script"
+    echo "Tidy Chrome Extension Build Script"
     echo
     echo "用法: $0 [选项]"
     echo

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "AI Language Translator",
+  "name": "Tidy",
   "version": "1.0.0",
   "description": "基于AI LLM的智能双语网页翻译插件",
   "permissions": [
@@ -26,7 +26,7 @@
   ],
   "action": {
     "default_popup": "src/popup/popup.html",
-    "default_title": "AI Language Translator",
+    "default_title": "Tidy",
     "default_icon": {
       "16": "src/assets/icon16.png",
       "32": "src/assets/icon32.png",

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI Language Translator</title>
+  <title>Tidy</title>
   <link rel="stylesheet" href="popup.css">
 </head>
 <body>
@@ -11,8 +11,8 @@
     <!-- 头部 -->
     <header class="popup-header">
       <div class="logo">
-        <img src="../assets/icon32.png" alt="AI Translator" class="logo-icon">
-        <h1>AI Translator</h1>
+        <img src="../assets/icon32.png" alt="Tidy" class="logo-icon">
+        <h1>Tidy</h1>
       </div>
       <div class="status-indicator" id="statusIndicator">
         <span class="status-dot"></span>

--- a/src/welcome/welcome.html
+++ b/src/welcome/welcome.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI Language Translator - 欢迎</title>
+  <title>Tidy - 欢迎</title>
   <style>
     * {
       margin: 0;
@@ -115,7 +115,7 @@
 <body>
   <div class="welcome-container">
     <div class="logo">🌐</div>
-    <h1>欢迎使用 AI Language Translator</h1>
+    <h1>欢迎使用 Tidy</h1>
     <p class="subtitle">基于 AI 大语言模型的智能双语翻译插件</p>
     
     <div class="features">

--- a/test.html
+++ b/test.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI Translator Test Page</title>
+  <title>Tidy Test Page</title>
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -97,14 +97,14 @@
 </head>
 <body>
   <div class="header">
-    <h1>🌐 AI Language Translator Test Page</h1>
+    <h1>🌐 Tidy Test Page</h1>
     <p>Use this page to test the AI translation extension functionality</p>
   </div>
 
   <div class="instructions">
     <h3>📋 Testing Instructions</h3>
     <ol>
-      <li>Make sure the AI Language Translator extension is installed and enabled</li>
+      <li>Make sure the Tidy extension is installed and enabled</li>
       <li>Configure your API key in the extension popup (click the extension icon)</li>
       <li>Enable translation in the popup</li>
       <li>Try the following test methods:</li>
@@ -128,7 +128,7 @@
     
     <div class="text-block">
       <h3>Technology Overview</h3>
-      <p>The AI Language Translator extension leverages state-of-the-art language models like GPT-4, Claude, and Gemini to provide high-quality translations. These models are trained on vast amounts of multilingual text data and can handle complex linguistic structures, idioms, and technical terminology.</p>
+      <p>The Tidy extension leverages state-of-the-art language models like GPT-4, Claude, and Gemini to provide high-quality translations. These models are trained on vast amounts of multilingual text data and can handle complex linguistic structures, idioms, and technical terminology.</p>
     </div>
     
     <div class="text-block">
@@ -230,7 +230,7 @@ function translateText(text, sourceLang, targetLang) {
     }
 
     // Log page load for debugging
-    console.log('AI Translator test page loaded');
+    console.log('Tidy test page loaded');
     console.log('Page contains translatable elements:', document.querySelectorAll('p, h1, h2, h3, li').length);
   </script>
 </body>

--- a/validate_extension.py
+++ b/validate_extension.py
@@ -204,7 +204,7 @@ def print_installation_info():
 
 def main():
     """Main validation function"""
-    print("🔍 AI Language Translator Chrome 扩展验证")
+    print("🔍 Tidy Chrome 扩展验证")
     print("="*60)
     
     # Change to script directory if manifest.json is not in current directory


### PR DESCRIPTION
Rename plugin from 'AI Language Translator' to 'Tidy' to align with user's requested name.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3b1395f-e162-4bb8-be49-0694cf3a4f82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d3b1395f-e162-4bb8-be49-0694cf3a4f82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

