### PR TITLE
Fix right-click translate and add page translation shortcut

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -45,5 +45,19 @@
       "resources": ["src/assets/*", "src/welcome/*"],
       "matches": ["<all_urls>"]
     }
-  ]
+  ],
+  "commands": {
+    "translate-page": {
+      "suggested_key": {
+        "default": "Alt+T"
+      },
+      "description": "翻译当前页面"
+    },
+    "toggle-translation": {
+      "suggested_key": {
+        "default": "Alt+Q"
+      },
+      "description": "切换翻译状态"
+    }
+  }
 }

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -11,6 +11,7 @@ class BackgroundService {
     this.setupMessageListener();
     this.setupContextMenus();
     this.setupInstallHandler();
+    this.setupCommandsListener();
   }
 
   // 设置消息监听器
@@ -123,6 +124,43 @@ class BackgroundService {
         console.log('Extension updated to version:', chrome.runtime.getManifest().version);
       }
     });
+  }
+
+  // 设置快捷键监听器
+  setupCommandsListener() {
+    chrome.commands.onCommand.addListener((command) => {
+      this.handleCommand(command);
+    });
+  }
+
+  // 处理快捷键命令
+  async handleCommand(command) {
+    try {
+      // 获取当前活动标签页
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (!tab) return;
+
+      const settings = await this.getSettings();
+
+      switch (command) {
+        case 'translate-page':
+          // 翻译当前页面
+          chrome.tabs.sendMessage(tab.id, {
+            action: 'translatePage',
+            settings: settings
+          });
+          break;
+
+        case 'toggle-translation':
+          // 切换翻译状态
+          chrome.tabs.sendMessage(tab.id, {
+            action: 'toggleTranslation'
+          });
+          break;
+      }
+    } catch (error) {
+      console.error('Command handler error:', error);
+    }
   }
 
   // 设置默认设置

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -67,6 +67,11 @@ class TranslationController {
         this.toggleTranslation();
         sendResponse({ success: true });
         break;
+      case 'showTranslationResult':
+        // 处理右键菜单翻译结果
+        this.showTranslationPopup(message.originalText, message.translation);
+        sendResponse({ success: true });
+        break;
     }
   }
 


### PR DESCRIPTION
Fixes unresponsive right-click text translation and adds keyboard shortcuts for page translation and toggling.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad865121-9911-44f1-b0c1-5b6630a265d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad865121-9911-44f1-b0c1-5b6630a265d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

