### PR TITLE
Directly replace original text with translated text

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -933,18 +933,11 @@ class TranslationController {
     element.appendChild(container);
   }
 
-  // 替换显示模式
+  // 替换显示模式 - 无样式，保持原文字体样式
   applyReplace(element, originalText, translation) {
     element.innerHTML = translation;
     element.title = `原文: ${originalText}`;
-    element.style.cssText = `
-      background: linear-gradient(120deg, rgba(79, 70, 229, 0.1) 0%, rgba(124, 58, 237, 0.1) 100%);
-      padding: 3px 6px;
-      border-radius: 4px;
-      border-bottom: 2px dotted #4f46e5;
-      cursor: help;
-      transition: all 0.2s ease;
-    `;
+    // 不应用任何样式，让译文以原文的字体样式显示
   }
 
   // 并排显示模式


### PR DESCRIPTION
Remove custom styling from 'Replace Original Text' display mode to show translations with original text's font style.

---
<a href="https://cursor.com/background-agent?bcId=bc-09111c97-20ed-42aa-bfbd-0a27c986a019">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09111c97-20ed-42aa-bfbd-0a27c986a019">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

