### PR TITLE
Update translation shortcut and prevent duplicate display

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,22 +43,22 @@
   "commands": {
     "translate-page": {
       "suggested_key": {
-        "default": "Alt+W",
-        "mac": "Alt+W"
+        "default": "Ctrl+W",
+        "mac": "Ctrl+W"
       },
       "description": "翻译当前页面"
     },
     "toggle-translation": {
       "suggested_key": {
-        "default": "Alt+A",
-        "mac": "Alt+A"
+        "default": "Ctrl+A",
+        "mac": "Ctrl+A"
       },
       "description": "切换翻译状态"
     },
     "clear-translation": {
       "suggested_key": {
-        "default": "Alt+C",
-        "mac": "Alt+C"
+        "default": "Ctrl+C",
+        "mac": "Ctrl+C"
       },
       "description": "清除翻译"
     }

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -338,13 +338,13 @@ class TranslationController {
   bindEvents() {
     // 绑定事件处理器
     this.boundKeydownHandler = (e) => {
-      // Option/Alt + A: 切换翻译（Mac/Win 双平台）
-      if ((e.altKey || e.metaKey) && e.key.toLowerCase() === 'a') {
+      // Ctrl + A: 切换翻译
+      if (e.ctrlKey && e.key.toLowerCase() === 'a') {
         e.preventDefault();
         this.toggleTranslation();
       }
-      // Option/Alt + W: 翻译整个页面
-      if ((e.altKey || e.metaKey) && e.key.toLowerCase() === 'w') {
+      // Ctrl + W: 翻译整个页面
+      if (e.ctrlKey && e.key.toLowerCase() === 'w') {
         e.preventDefault();
         this.translatePage();
       }
@@ -450,7 +450,12 @@ class TranslationController {
   async toggleTranslation() {
     if (this.isTranslating) {
       this.clearTranslation();
+    } else if (this.translatedElements.size > 0) {
+      // 如果页面已翻译，则清除翻译
+      this.clearTranslation();
+      this.showNotification('翻译已清除', 'info');
     } else {
+      // 如果页面未翻译，则开始翻译
       await this.translatePage();
     }
   }
@@ -458,6 +463,12 @@ class TranslationController {
   // 翻译页面 - 使用最新的分段并发翻译策略
   async translatePage(settings = null) {
     if (this.isTranslating) return;
+
+    // 检查是否已有翻译内容，如果有则显示提示而不重复翻译
+    if (this.translatedElements.size > 0) {
+      this.showNotification('页面已翻译，按 Ctrl+A 可切换翻译状态', 'info');
+      return;
+    }
 
     try {
       this.isTranslating = true;


### PR DESCRIPTION
Update translation shortcuts to use Ctrl key and prevent duplicate page translations.

The `translatePage` method now checks if the page already has translated elements and provides a user notification instead of re-translating. The `toggleTranslation` method is also improved to clear existing translations when `Ctrl+A` is pressed on an already translated page.

---
<a href="https://cursor.com/background-agent?bcId=bc-af650d0a-2738-4e41-971b-ffbb81c7bb53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af650d0a-2738-4e41-971b-ffbb81c7bb53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

