### PR TITLE
Update translation modes and API key handling

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -476,8 +476,10 @@ class TranslationController {
 
       const currentSettings = settings || this.settings;
       
-      // 检查API密钥
-      if (!currentSettings.apiKey) {
+      // 检查API密钥 (Microsoft Translator 和 Ollama 不需要)
+      if (!currentSettings.apiKey && 
+          currentSettings.aiModel !== 'microsoft-translator' && 
+          currentSettings.aiModel !== 'ollama') {
         this.hideProgress();
         this.showNotification('请先在插件设置中配置API密钥', 'warning');
         return;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -360,8 +360,10 @@ class PopupController {
   // 翻译当前页面
   async translateCurrentPage() {
     try {
-      // 检查API密钥
-      if (!this.settings.apiKey) {
+      // 检查API密钥 (Microsoft Translator 和 Ollama 不需要)
+      if (!this.settings.apiKey && 
+          this.settings.aiModel !== 'microsoft-translator' && 
+          this.settings.aiModel !== 'ollama') {
         this.showNotification('请先配置API密钥', 'warning');
         return;
       }
@@ -423,7 +425,10 @@ class PopupController {
 
   // 测试API
   async testAPI() {
-    if (!this.settings.apiKey) {
+    // Microsoft Translator 和 Ollama 不需要API Key
+    if (!this.settings.apiKey && 
+        this.settings.aiModel !== 'microsoft-translator' && 
+        this.settings.aiModel !== 'ollama') {
       this.showNotification('请先输入API Key', 'warning');
       return;
     }


### PR DESCRIPTION
Make API keys optional for Microsoft Translator (now using MyMemory API) and Ollama.

The Microsoft Translator implementation was updated to use the free MyMemory API to allow its use without requiring an API key.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbe165fb-c3a1-4c02-bb80-e36b64b4b41d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cbe165fb-c3a1-4c02-bb80-e36b64b4b41d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

